### PR TITLE
feat(core): Change how the plugin should be used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ tasks.withType(JavaCompile) {
   options.compilerArgs << '-Xlint:unchecked'
   options.deprecation = true
 }
+
 dependencyLocking {
   lockAllConfigurations()
 }
@@ -102,6 +103,9 @@ testing {
 }
 
 prettyJupiter {
+  failure {
+    maxMessageLines = 30
+  }
   duration {
     customThreshold = [testkit: 1000]
   }

--- a/src/main/java/io/github/joselion/strictnullcheck/lib/StrictNullCheckExtension.java
+++ b/src/main/java/io/github/joselion/strictnullcheck/lib/StrictNullCheckExtension.java
@@ -18,25 +18,20 @@ import lombok.Getter;
 public class StrictNullCheckExtension {
 
   @Input
-  private final ListProperty<String> annotations;
-
-  @Input
   private final Property<String> generatedDir;
 
-  @Input
-  private final Property<String> packageJavadoc;
+  @Nested
+  private final PackageInfo packageInfo;
 
   @Nested
-  private final Versions versions;
+  private final Source source;
 
   @Inject
   public StrictNullCheckExtension(final ObjectFactory objects, final ProjectLayout layout) {
-    this.annotations = objects.listProperty(String.class);
     this.generatedDir = objects.property(String.class);
-    this.packageJavadoc = objects.property(String.class);
-    this.versions = objects.newInstance(Versions.class);
+    this.packageInfo = objects.newInstance(PackageInfo.class);
+    this.source = objects.newInstance(Source.class);
 
-    this.annotations.convention(List.of("org.eclipse.jdt.annotation.NonNullByDefault"));
     this.generatedDir.convention(
       layout
         .getBuildDirectory()
@@ -45,38 +40,114 @@ public class StrictNullCheckExtension {
         .getPath()
         .concat("/generated/sources/strictNullCheck")
     );
-    this.packageJavadoc.convention("");
   }
 
-  public void useSpring() {
-    this.annotations.convention(
-      List.of(
-        "org.springframework.lang.NonNullApi",
-        "org.springframework.lang.NonNullFields"
-      )
-    );
+  public void packageInfo(final Action<PackageInfo> action) {
+    action.execute(this.packageInfo);
   }
 
-  public void versions(final Action<Versions> action) {
-    action.execute(this.versions);
+  public void source(final Action<Source> action) {
+    action.execute(this.source);
   }
 
   @Getter
-  public static class Versions {
+  public static class PackageInfo {
 
     @Input
-    private final Property<String> eclipseAnnotations;
+    private final ListProperty<String> imports;
 
     @Input
-    private final Property<String> findBugs;
+    private final ListProperty<String> annotations;
+
+    @Input
+    private final Property<String> javadoc;
 
     @Inject
-    public Versions(final ObjectFactory objects) {
-      this.eclipseAnnotations = objects.property(String.class);
-      this.findBugs = objects.property(String.class);
+    public PackageInfo(final ObjectFactory objects) {
+      this.imports = objects.listProperty(String.class);
+      this.annotations = objects.listProperty(String.class);
+      this.javadoc = objects.property(String.class);
 
-      this.eclipseAnnotations.convention("2.2.600");
-      this.findBugs.convention("3.0.2");
+      this.imports.convention(List.of("javax.annotation.ParametersAreNonnullByDefault"));
+      this.annotations.convention(List.of("@ParametersAreNonnullByDefault"));
+      this.javadoc.convention("");
+    }
+
+    public void useSpring() {
+      this.imports.set(
+        List.of(
+          "org.springframework.lang.NonNullApi",
+          "org.springframework.lang.NonNullFields"
+        )
+      );
+      this.annotations.set(List.of("@NonNullApi", "@NonNullFields"));
+    }
+
+    public void useEclipse() {
+      this.imports.set(
+        List.of(
+          "static org.eclipse.jdt.annotation.DefaultLocation.ARRAY_CONTENTS",
+          "static org.eclipse.jdt.annotation.DefaultLocation.FIELD",
+          "static org.eclipse.jdt.annotation.DefaultLocation.PARAMETER",
+          "static org.eclipse.jdt.annotation.DefaultLocation.RETURN_TYPE",
+          "static org.eclipse.jdt.annotation.DefaultLocation.TYPE_ARGUMENT",
+          "static org.eclipse.jdt.annotation.DefaultLocation.TYPE_BOUND",
+          "static org.eclipse.jdt.annotation.DefaultLocation.TYPE_PARAMETER",
+          "org.eclipse.jdt.annotation.NonNullByDefault"
+        )
+      );
+      this.annotations.set(
+        List.of(
+          """
+          @NonNullByDefault({
+            ARRAY_CONTENTS,
+            FIELD, PARAMETER,
+            RETURN_TYPE,
+            TYPE_ARGUMENT,
+            TYPE_BOUND,
+            TYPE_PARAMETER
+          })\
+          """
+        )
+      );
+    }
+  }
+
+  @Getter
+  public static class Source {
+
+    @Input
+    private final ListProperty<String> dependencies;
+
+    @Inject
+    public Source(final ObjectFactory objects) {
+      this.dependencies = objects.listProperty(String.class);
+
+      this.dependencies.convention(List.of());
+    }
+
+    public void addFindBugs(final String version) {
+      this.dependencies.add("com.google.code.findbugs:jsr305:".concat(version));
+    }
+
+    public void addFindBugs() {
+      this.addFindBugs("+");
+    }
+
+    public void addSpotBugs(final String version) {
+      this.dependencies.add("com.github.spotbugs:spotbugs-annotations:".concat(version));
+    }
+
+    public void addSpotBugs() {
+      this.addSpotBugs("+");
+    }
+
+    public void addEclipse(final String version) {
+      this.dependencies.add("org.eclipse.jdt:org.eclipse.jdt.annotation:".concat(version));
+    }
+
+    public void addEclipse() {
+      this.addEclipse("+");
     }
   }
 }

--- a/src/test/java/io/github/joselion/strictnullcheck/StrictNullCheckPluginTest.java
+++ b/src/test/java/io/github/joselion/strictnullcheck/StrictNullCheckPluginTest.java
@@ -14,7 +14,7 @@ import testing.annotations.UnitTest;
 @UnitTest class StrictNullCheckPluginTest {
 
   @Nested class when_the_plugin_is_applied {
-    @Test void creates_strictNullCheck_extension_and_registers_generatePackageInfo_task() {
+    @Test void creates_strictNullCheck_extension() {
       final var project = ProjectBuilder.builder().build();
       final var plugins = project.getPlugins();
 
@@ -22,11 +22,21 @@ import testing.annotations.UnitTest;
       plugins.apply("io.github.joselion.strict-null-check");
 
       final var extension = project.getExtensions().findByName("strictNullCheck");
-      final var generateTask = project.getTasks().findByName("generatePackageInfo");
 
       assertThat(extension)
         .isNotNull()
         .isInstanceOf(StrictNullCheckExtension.class);
+    }
+
+    @Test void registers_generatePackageInfo_task() {
+      final var project = ProjectBuilder.builder().build();
+      final var plugins = project.getPlugins();
+
+      plugins.apply("java");
+      plugins.apply("io.github.joselion.strict-null-check");
+
+      final var generateTask = project.getTasks().findByName("generatePackageInfo");
+
       assertThat(generateTask)
         .isNotNull()
         .isInstanceOf(GeneratePackageInfoTask.class);

--- a/src/test/java/io/github/joselion/strictnullcheck/lib/StrictNullCheckExtensionTest.java
+++ b/src/test/java/io/github/joselion/strictnullcheck/lib/StrictNullCheckExtensionTest.java
@@ -15,30 +15,112 @@ import testing.annotations.UnitTest;
       final var project = ProjectBuilder.builder().build();
       final var extension = project.getExtensions().create("strictNullCheck", StrictNullCheckExtension.class);
       final var buildDir = project.getLayout().getBuildDirectory().get().toString();
-      final var annotations = extension.getAnnotations().get();
       final var generatedDir = extension.getGeneratedDir().get();
-      final var packageJavadoc = extension.getPackageJavadoc().get();
-      final var versions = extension.getVersions();
+      final var imports = extension.getPackageInfo().getImports().get();
+      final var annotations = extension.getPackageInfo().getAnnotations().get();
+      final var javadoc = extension.getPackageInfo().getJavadoc().get();
+      final var dependencies = extension.getSource().getDependencies().get();
 
-      assertThat(annotations).containsExactly("org.eclipse.jdt.annotation.NonNullByDefault");
+      assertThat(imports).containsExactly("javax.annotation.ParametersAreNonnullByDefault");
+      assertThat(annotations).containsExactly("@ParametersAreNonnullByDefault");
       assertThat(generatedDir).isEqualTo(buildDir.concat("/generated/sources/strictNullCheck"));
-      assertThat(packageJavadoc).isEmpty();
-      assertThat(versions.getEclipseAnnotations().get()).isEqualTo("2.2.600");
-      assertThat(versions.getFindBugs().get()).isEqualTo("3.0.2");
+      assertThat(javadoc).isEmpty();
+      assertThat(dependencies).isEmpty();
     }
   }
 
-  @Nested class useSpring {
-    @Test void sets_Spring_annotations() {
-      final var project = ProjectBuilder.builder().build();
-      final var extension = project.getExtensions().create("strictNullCheck", StrictNullCheckExtension.class);
+  @Nested class packageInfo {
+    @Nested class useSpring {
+      @Test void sets_Spring_annotations() {
+        final var project = ProjectBuilder.builder().build();
+        final var extension = project.getExtensions().create("strictNullCheck", StrictNullCheckExtension.class);
+        final var packageInfo = extension.getPackageInfo();
 
-      extension.useSpring();
+        packageInfo.useSpring();
 
-      assertThat(extension.getAnnotations().get()).containsExactly(
-        "org.springframework.lang.NonNullApi",
-        "org.springframework.lang.NonNullFields"
-      );
+        assertThat(packageInfo.getImports().get()).containsExactly(
+          "org.springframework.lang.NonNullApi",
+          "org.springframework.lang.NonNullFields"
+        );
+        assertThat(packageInfo.getAnnotations().get()).containsExactly(
+          "@NonNullApi",
+          "@NonNullFields"
+        );
+      }
+    }
+
+    @Nested class useEclipse {
+      @Test void sets_Eclipse_annotation() {
+        final var project = ProjectBuilder.builder().build();
+        final var extension = project.getExtensions().create("strictNullCheck", StrictNullCheckExtension.class);
+        final var packageInfo = extension.getPackageInfo();
+
+        packageInfo.useEclipse();
+
+        assertThat(packageInfo.getImports().get()).containsExactly(
+          "static org.eclipse.jdt.annotation.DefaultLocation.ARRAY_CONTENTS",
+          "static org.eclipse.jdt.annotation.DefaultLocation.FIELD",
+          "static org.eclipse.jdt.annotation.DefaultLocation.PARAMETER",
+          "static org.eclipse.jdt.annotation.DefaultLocation.RETURN_TYPE",
+          "static org.eclipse.jdt.annotation.DefaultLocation.TYPE_ARGUMENT",
+          "static org.eclipse.jdt.annotation.DefaultLocation.TYPE_BOUND",
+          "static org.eclipse.jdt.annotation.DefaultLocation.TYPE_PARAMETER",
+          "org.eclipse.jdt.annotation.NonNullByDefault"
+        );
+        assertThat(packageInfo.getAnnotations().get()).containsExactly(
+          """
+          @NonNullByDefault({
+            ARRAY_CONTENTS,
+            FIELD, PARAMETER,
+            RETURN_TYPE,
+            TYPE_ARGUMENT,
+            TYPE_BOUND,
+            TYPE_PARAMETER
+          })\
+          """
+        );
+      }
+    }
+  }
+
+  @Nested class source {
+    @Nested class addFindBugs {
+      @Test void adds_the_FindBugs_dependency() {
+        final var project = ProjectBuilder.builder().build();
+        final var extension = project.getExtensions().create("strictNullCheck", StrictNullCheckExtension.class);
+
+        extension.getSource().addFindBugs();
+
+        final var dependencies = extension.getSource().getDependencies().get();
+
+        assertThat(dependencies).contains("com.google.code.findbugs:jsr305:+");
+      }
+    }
+
+    @Nested class addSpotBugs {
+      @Test void adds_the_SpotBugs_dependency() {
+        final var project = ProjectBuilder.builder().build();
+        final var extension = project.getExtensions().create("strictNullCheck", StrictNullCheckExtension.class);
+
+        extension.getSource().addSpotBugs();
+
+        final var dependencies = extension.getSource().getDependencies().get();
+
+        assertThat(dependencies).contains("com.github.spotbugs:spotbugs-annotations:+");
+      }
+    }
+
+    @Nested class addEclipse {
+      @Test void adds_the_SpotBugs_dependency() {
+        final var project = ProjectBuilder.builder().build();
+        final var extension = project.getExtensions().create("strictNullCheck", StrictNullCheckExtension.class);
+
+        extension.getSource().addEclipse();
+
+        final var dependencies = extension.getSource().getDependencies().get();
+
+        assertThat(dependencies).contains("org.eclipse.jdt:org.eclipse.jdt.annotation:+");
+      }
     }
   }
 }

--- a/src/testkit/java/io/github/joselion/strictnullcheck/StrictNullCheckPluginTkTest.java
+++ b/src/testkit/java/io/github/joselion/strictnullcheck/StrictNullCheckPluginTkTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import testing.Helpers;
 import testing.annotations.TestkitTest;
 
-@TestkitTest class StrictNullCheckPluginTest {
+@TestkitTest class StrictNullCheckPluginTkTest {
 
   @Nested class when_the_plugin_is_applied {
     @Test void generates_package_info_files_before_compileJava_task() throws IOException {
@@ -21,6 +21,12 @@ import testing.annotations.TestkitTest;
         plugins {
           id "java"
           id "io.github.joselion.strict-null-check"
+        }
+
+        strictNullCheck {
+          source {
+            addFindBugs()
+          }
         }
 
         repositories {
@@ -37,13 +43,13 @@ import testing.annotations.TestkitTest;
         /**
          * This package is checked for {@code null} by the following annotations:
          * <ul>
-         *   <li>org.eclipse.jdt.annotation.NonNullByDefault</li>
+         *   <li>javax.annotation.ParametersAreNonnullByDefault</li>
          * </ul>
          */
-        @NonNullByDefault
+        @ParametersAreNonnullByDefault
         package com.example.app;
 
-        import org.eclipse.jdt.annotation.NonNullByDefault;
+        import javax.annotation.ParametersAreNonnullByDefault;
         """
       );
     }
@@ -60,11 +66,12 @@ import testing.annotations.TestkitTest;
           }
 
           strictNullCheck {
-            annotations = [
+            packageInfo.annotations = [
               'my.custom.annotation.NullApi',
-              'my.custom.annotation.NullFields'
+              'my.custom.annotation.NullFields',
             ]
-            versions.findBugs = '1.0.0';
+            source.dependencies = ['my.custom:annotations:1.5.3']
+            source.addFindBugs()
           }
 
           repositories {
@@ -73,8 +80,8 @@ import testing.annotations.TestkitTest;
 
           task showConfig() {
             doLast {
-              println("*** annotations: ${strictNullCheck.annotations.get()}")
-              println("*** versions.findBugs: ${strictNullCheck.versions.findBugs.get()}")
+              println("*** packageInfo.annotations: ${strictNullCheck.packageInfo.annotations.get()}")
+              println("*** source.dependencies: ${strictNullCheck.source.dependencies.get()}")
             }
           }
           """
@@ -83,8 +90,8 @@ import testing.annotations.TestkitTest;
         final var result = Helpers.runTask("showConfig");
 
         assertThat(result.getOutput())
-          .contains("*** annotations: [my.custom.annotation.NullApi, my.custom.annotation.NullFields]")
-          .contains("*** versions.findBugs: 1.0.0")
+          .contains("*** packageInfo.annotations: [my.custom.annotation.NullApi, my.custom.annotation.NullFields]")
+          .contains("*** source.dependencies: [my.custom:annotations:1.5.3, com.google.code.findbugs:jsr305:+]")
           .contains("BUILD SUCCESSFUL");
       }
     }
@@ -99,9 +106,15 @@ import testing.annotations.TestkitTest;
           }
 
           strictNullCheck {
-            versions {
-              eclipseAnnotations = '1.1.000'
-              findBugs = '1.0.0'
+            packageInfo {
+              annotations = [
+                'my.custom.annotation.NullApi',
+                'my.custom.annotation.NullFields',
+              ]
+            }
+            source {
+              dependencies = ['my.custom:annotations:1.5.3']
+              addFindBugs()
             }
           }
 
@@ -111,8 +124,8 @@ import testing.annotations.TestkitTest;
 
           task showConfig() {
             doLast {
-              println("*** varsions.eclipseAnnotations: ${strictNullCheck.versions.eclipseAnnotations.get()}")
-              println("*** versions.findBugs: ${strictNullCheck.versions.findBugs.get()}")
+              println("*** packageInfo.annotations: ${strictNullCheck.packageInfo.annotations.get()}")
+              println("*** source.dependencies: ${strictNullCheck.source.dependencies.get()}")
             }
           }
           """
@@ -121,8 +134,8 @@ import testing.annotations.TestkitTest;
         final var result = Helpers.runTask("showConfig");
 
         assertThat(result.getOutput())
-          .contains("*** varsions.eclipseAnnotations: 1.1.000")
-          .contains("*** versions.findBugs: 1.0.0")
+          .contains("*** packageInfo.annotations: [my.custom.annotation.NullApi, my.custom.annotation.NullFields]")
+          .contains("*** source.dependencies: [my.custom:annotations:1.5.3, com.google.code.findbugs:jsr305:+]")
           .contains("BUILD SUCCESSFUL");
       }
     }

--- a/src/testkit/java/io/github/joselion/strictnullcheck/lib/GeneratePackageInfoTaskTkTest.java
+++ b/src/testkit/java/io/github/joselion/strictnullcheck/lib/GeneratePackageInfoTaskTkTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import testing.Helpers;
 import testing.annotations.TestkitTest;
 
-@TestkitTest class GeneratePackageInfoTaskTest {
+@TestkitTest class GeneratePackageInfoTaskTkTest {
 
   @Nested class when_the_task_runs {
     @Test void generates_package_info_file_if_they_dont_aready_exist() throws IOException {
@@ -23,6 +23,12 @@ import testing.annotations.TestkitTest;
         plugins {
           id "java"
           id "io.github.joselion.strict-null-check"
+        }
+
+        strictNullCheck {
+          source {
+            addFindBugs()
+          }
         }
 
         repositories {


### PR DESCRIPTION
BREAKING CHANGE: The `strictNullCheck` extension has changed to allow configuration of the imports and the annotations separately, with useful shorcut functions like `useEclipse()` and `useSpring()`. It also allows to specifically add the source dependencies of the annotations, also with useful shortcuts like `addFindBugs()` and `addSpotBugs()`. The default conventions of the extensions has also changed, by default now only `javax.annotation.ParametersAreNonnullByDefault` annotation is used wihout adding any source dependency. Additionally, the `generatePackageInfo` task can no longer be configured directly, chenges should always come from the extension.