### PR TITLE
feat(ext): Lazy dependencies configuration

### DIFF
--- a/src/main/java/io/github/joselion/strictnullcheck/StrictNullCheckPlugin.java
+++ b/src/main/java/io/github/joselion/strictnullcheck/StrictNullCheckPlugin.java
@@ -42,24 +42,5 @@ public class StrictNullCheckPlugin implements Plugin<Project> {
             .srcDir(extension.getGeneratedDir().get().concat("/java/main"))
         );
     });
-
-    project.afterEvaluate(evaluated -> {
-      final var allCompileOnly = evaluated
-        .getConfigurations()
-        .matching(configuration -> {
-          final var name = configuration.getName();
-          return name.startsWith("compileOnly") || name.endsWith("CompileOnly");
-        });
-
-      allCompileOnly.configureEach(configuration ->
-        extension
-          .getSource()
-          .getDependencies()
-          .get()
-          .stream()
-          .map(evaluated.getDependencies()::create)
-          .forEach(configuration.getDependencies()::add)
-      );
-    });
   }
 }

--- a/src/main/java/io/github/joselion/strictnullcheck/lib/StrictNullCheckExtension.java
+++ b/src/main/java/io/github/joselion/strictnullcheck/lib/StrictNullCheckExtension.java
@@ -5,11 +5,13 @@ import java.util.List;
 import javax.inject.Inject;
 
 import org.gradle.api.Action;
+import org.gradle.api.Project;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 
 import lombok.Getter;
@@ -23,14 +25,14 @@ public class StrictNullCheckExtension {
   @Nested
   private final PackageInfo packageInfo;
 
-  @Nested
-  private final Source source;
+  @Internal
+  private final Project project;
 
   @Inject
-  public StrictNullCheckExtension(final ObjectFactory objects, final ProjectLayout layout) {
+  public StrictNullCheckExtension(final ObjectFactory objects, final ProjectLayout layout, final Project project) {
     this.generatedDir = objects.property(String.class);
     this.packageInfo = objects.newInstance(PackageInfo.class);
-    this.source = objects.newInstance(Source.class);
+    this.project = project;
 
     this.generatedDir.convention(
       layout
@@ -46,8 +48,44 @@ public class StrictNullCheckExtension {
     action.execute(this.packageInfo);
   }
 
-  public void source(final Action<Source> action) {
-    action.execute(this.source);
+  public void addFindBugs(final String version) {
+    this.addDependency("com.google.code.findbugs:jsr305:".concat(version));
+  }
+
+  public void addFindBugs() {
+    this.addFindBugs("3.0.2");
+  }
+
+  public void addSpotBugs(final String version) {
+    this.addDependency("com.github.spotbugs:spotbugs-annotations:".concat(version));
+  }
+
+  public void addSpotBugs() {
+    this.addSpotBugs("4.7.3");
+  }
+
+  public void addEclipse(final String version) {
+    this.addDependency("org.eclipse.jdt:org.eclipse.jdt.annotation:".concat(version));
+  }
+
+  public void addEclipse() {
+    this.addEclipse("2.2.700");
+  }
+
+  private void addDependency(final String notation) {
+    final var dependency = this.project.getDependencies().create(notation);
+    final var allCompileOnly = this.project
+      .getConfigurations()
+      .matching(config -> {
+        final var name = config.getName();
+        return name.startsWith("compileOnly") || name.endsWith("CompileOnly");
+      });
+
+    allCompileOnly.configureEach(config ->
+      config
+        .getDependencies()
+        .add(dependency)
+    );
   }
 
   @Getter
@@ -110,44 +148,6 @@ public class StrictNullCheckExtension {
           """
         )
       );
-    }
-  }
-
-  @Getter
-  public static class Source {
-
-    @Input
-    private final ListProperty<String> dependencies;
-
-    @Inject
-    public Source(final ObjectFactory objects) {
-      this.dependencies = objects.listProperty(String.class);
-
-      this.dependencies.convention(List.of());
-    }
-
-    public void addFindBugs(final String version) {
-      this.dependencies.add("com.google.code.findbugs:jsr305:".concat(version));
-    }
-
-    public void addFindBugs() {
-      this.addFindBugs("3.0.2");
-    }
-
-    public void addSpotBugs(final String version) {
-      this.dependencies.add("com.github.spotbugs:spotbugs-annotations:".concat(version));
-    }
-
-    public void addSpotBugs() {
-      this.addSpotBugs("4.7.3");
-    }
-
-    public void addEclipse(final String version) {
-      this.dependencies.add("org.eclipse.jdt:org.eclipse.jdt.annotation:".concat(version));
-    }
-
-    public void addEclipse() {
-      this.addEclipse("2.2.700");
     }
   }
 }

--- a/src/test/java/io/github/joselion/strictnullcheck/lib/StrictNullCheckExtensionTest.java
+++ b/src/test/java/io/github/joselion/strictnullcheck/lib/StrictNullCheckExtensionTest.java
@@ -19,13 +19,11 @@ import testing.annotations.UnitTest;
       final var imports = extension.getPackageInfo().getImports().get();
       final var annotations = extension.getPackageInfo().getAnnotations().get();
       final var javadoc = extension.getPackageInfo().getJavadoc().get();
-      final var dependencies = extension.getSource().getDependencies().get();
 
       assertThat(imports).containsExactly("javax.annotation.ParametersAreNonnullByDefault");
       assertThat(annotations).containsExactly("@ParametersAreNonnullByDefault");
       assertThat(generatedDir).isEqualTo(buildDir.concat("/generated/sources/strictNullCheck"));
       assertThat(javadoc).isEmpty();
-      assertThat(dependencies).isEmpty();
     }
   }
 
@@ -79,47 +77,6 @@ import testing.annotations.UnitTest;
           })\
           """
         );
-      }
-    }
-  }
-
-  @Nested class source {
-    @Nested class addFindBugs {
-      @Test void adds_the_FindBugs_dependency() {
-        final var project = ProjectBuilder.builder().build();
-        final var extension = project.getExtensions().create("strictNullCheck", StrictNullCheckExtension.class);
-
-        extension.getSource().addFindBugs();
-
-        final var dependencies = extension.getSource().getDependencies().get();
-
-        assertThat(dependencies).contains("com.google.code.findbugs:jsr305:3.0.2");
-      }
-    }
-
-    @Nested class addSpotBugs {
-      @Test void adds_the_SpotBugs_dependency() {
-        final var project = ProjectBuilder.builder().build();
-        final var extension = project.getExtensions().create("strictNullCheck", StrictNullCheckExtension.class);
-
-        extension.getSource().addSpotBugs();
-
-        final var dependencies = extension.getSource().getDependencies().get();
-
-        assertThat(dependencies).contains("com.github.spotbugs:spotbugs-annotations:4.7.3");
-      }
-    }
-
-    @Nested class addEclipse {
-      @Test void adds_the_SpotBugs_dependency() {
-        final var project = ProjectBuilder.builder().build();
-        final var extension = project.getExtensions().create("strictNullCheck", StrictNullCheckExtension.class);
-
-        extension.getSource().addEclipse();
-
-        final var dependencies = extension.getSource().getDependencies().get();
-
-        assertThat(dependencies).contains("org.eclipse.jdt:org.eclipse.jdt.annotation:2.2.700");
       }
     }
   }

--- a/src/testkit/java/io/github/joselion/strictnullcheck/StrictNullCheckPluginTkTest.java
+++ b/src/testkit/java/io/github/joselion/strictnullcheck/StrictNullCheckPluginTkTest.java
@@ -24,9 +24,7 @@ import testing.annotations.TestkitTest;
         }
 
         strictNullCheck {
-          source {
-            addFindBugs()
-          }
+          addFindBugs()
         }
 
         repositories {
@@ -70,8 +68,7 @@ import testing.annotations.TestkitTest;
               'my.custom.annotation.NullApi',
               'my.custom.annotation.NullFields',
             ]
-            source.dependencies = ['my.custom:annotations:1.5.3']
-            source.addFindBugs()
+            addFindBugs()
           }
 
           repositories {
@@ -80,8 +77,9 @@ import testing.annotations.TestkitTest;
 
           task showConfig() {
             doLast {
+              def deps = configurations.compileOnly.dependencies.collect { "$it.group:$it.name:$it.version" }
               println("*** packageInfo.annotations: ${strictNullCheck.packageInfo.annotations.get()}")
-              println("*** source.dependencies: ${strictNullCheck.source.dependencies.get()}")
+              println("*** dependencies: $deps")
             }
           }
           """
@@ -91,7 +89,7 @@ import testing.annotations.TestkitTest;
 
         assertThat(result.getOutput())
           .contains("*** packageInfo.annotations: [my.custom.annotation.NullApi, my.custom.annotation.NullFields]")
-          .contains("*** source.dependencies: [my.custom:annotations:1.5.3, com.google.code.findbugs:jsr305:3.0.2]")
+          .contains("*** dependencies: [com.google.code.findbugs:jsr305:3.0.2]")
           .contains("BUILD SUCCESSFUL");
       }
     }
@@ -112,10 +110,7 @@ import testing.annotations.TestkitTest;
                 'my.custom.annotation.NullFields',
               ]
             }
-            source {
-              dependencies = ['my.custom:annotations:1.5.3']
-              addFindBugs()
-            }
+            addFindBugs()
           }
 
           repositories {
@@ -124,8 +119,9 @@ import testing.annotations.TestkitTest;
 
           task showConfig() {
             doLast {
+              def deps = configurations.compileOnly.dependencies.collect { "$it.group:$it.name:$it.version" }
               println("*** packageInfo.annotations: ${strictNullCheck.packageInfo.annotations.get()}")
-              println("*** source.dependencies: ${strictNullCheck.source.dependencies.get()}")
+              println("*** dependencies: $deps")
             }
           }
           """
@@ -135,7 +131,7 @@ import testing.annotations.TestkitTest;
 
         assertThat(result.getOutput())
           .contains("*** packageInfo.annotations: [my.custom.annotation.NullApi, my.custom.annotation.NullFields]")
-          .contains("*** source.dependencies: [my.custom:annotations:1.5.3, com.google.code.findbugs:jsr305:3.0.2]")
+          .contains("*** dependencies: [com.google.code.findbugs:jsr305:3.0.2]")
           .contains("BUILD SUCCESSFUL");
       }
     }

--- a/src/testkit/java/io/github/joselion/strictnullcheck/lib/GeneratePackageInfoTaskTkTest.java
+++ b/src/testkit/java/io/github/joselion/strictnullcheck/lib/GeneratePackageInfoTaskTkTest.java
@@ -26,9 +26,7 @@ import testing.annotations.TestkitTest;
         }
 
         strictNullCheck {
-          source {
-            addFindBugs()
-          }
+          addFindBugs()
         }
 
         repositories {


### PR DESCRIPTION
BREAKING CHANGES: The `strictNullCheck.sources` property of the extension was removed to encourage a lazy configuration. The methods that used to be inside `strictNullCheck.sources` ar now at `strictNullCheck` level. Also, it's not possible to add custom dependencies from the plugin extension anymore. If you want to add custom annotations, use Gradle's `dependencies` DSL as usual and configure `strictNullCheck.packageInfo` accordingly.